### PR TITLE
Demo connection

### DIFF
--- a/examples/smart-app/run.sh
+++ b/examples/smart-app/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+jupyterhub -f ./sample_jupyter_config.py –-log-level=DEBUG

--- a/examples/smart-app/run.sh
+++ b/examples/smart-app/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-jupyterhub -f ./sample_jupyter_config.py –-log-level=DEBUG
+jupyterhub -f ./sample_jupyter_config.py --log-level=DEBUG

--- a/examples/smart-app/sample_jupyter_config.py
+++ b/examples/smart-app/sample_jupyter_config.py
@@ -1,18 +1,24 @@
-from oauthenticator.generic import GenericOAuthenticator
 import requests
+
+from oauthenticator.generic import GenericOAuthenticator
 
 # Base url for a simulated FHIR application, by running docker compose setup from https://github.com/smart-on-fhir/smart-dev-sandbox
 # Configuration in the sandbox:
-# - Launch Type: Provider Standalone Launch
+# - Launch Type: Provider EHR Launch (disable "Simulate Launch within the EHR user interface")
 # - FHIR Version: R4 (most modern)
 # - Providers:  [3]
-fhir_base_url = "http://localhost:4013/v/r4/sim/eyJoIjoiMSIsImoiOiIxIiwiZSI6IjMifQ/fhir"
+fhir_base_url = "http://localhost:4013/v/r4/fhir"
 # Location where a SMART on FHIR application broadcasts configuration
 smart_config_location = ".well-known/smart-configuration"
 client_id = '9dbfaca0-9b85-49b6-bddd-d5eb638c2156'
 client_secret = 'unguessableclientsecret'
-id_scopes = ["openid", "fhirUser"]  # both are required
-
+id_scopes = [
+    "openid",
+    "fhirUser",
+    "launch",
+    "launch/patient",
+    "patient/*.*",
+]
 
 # Generic OAuthenticator
 c.JupyterHub.authenticator_class = GenericOAuthenticator
@@ -36,3 +42,12 @@ for scope in c.GenericOAuthenticator.scope:
 c.GenericOAuthenticator.userdata_from_id_token = True
 # Only one field to derive a name from, and it contains (at least) slashes
 c.GenericOAuthenticator.username_claim = lambda r: r['fhirUser'].replace('/', '_')
+"""
+With scopes "launch" and "patient/*.*" you get an access token in addition to an ID token. 
+You can't use that access token to get userdata, but you can get it for patient data.
+
+# You can abuse the c.GenericOAuthenticator.userdata_url to be something like 
+# f"{fhir_base_url}/Observation/9" to fetch observations with the access token.
+For the demo endpoint it's not entirely clear to me how to discover the endpoint and params that provide proper user data,
+but that's probably application dependent.
+"""

--- a/examples/smart-app/sample_jupyter_config.py
+++ b/examples/smart-app/sample_jupyter_config.py
@@ -1,0 +1,38 @@
+from oauthenticator.generic import GenericOAuthenticator
+import requests
+
+# Base url for a simulated FHIR application, by running docker compose setup from https://github.com/smart-on-fhir/smart-dev-sandbox
+# Configuration in the sandbox:
+# - Launch Type: Provider Standalone Launch
+# - FHIR Version: R4 (most modern)
+# - Providers:  [3]
+fhir_base_url = "http://localhost:4013/v/r4/sim/eyJoIjoiMSIsImoiOiIxIiwiZSI6IjMifQ/fhir"
+# Location where a SMART on FHIR application broadcasts configuration
+smart_config_location = ".well-known/smart-configuration"
+client_id = '9dbfaca0-9b85-49b6-bddd-d5eb638c2156'
+client_secret = 'unguessableclientsecret'
+id_scopes = ["openid", "fhirUser"]  # both are required
+
+
+# Generic OAuthenticator
+c.JupyterHub.authenticator_class = GenericOAuthenticator
+c.GenericOAuthenticator.oauth_callback_url = 'http://localhost:8000/hub/oauth_callback'
+c.GenericOAuthenticator.client_id = client_id
+c.GenericOAuthenticator.client_secret = client_secret
+c.GenericOAuthenticator.scope = id_scopes
+c.GenericOAuthenticator.allow_all = True
+c.Application.log_level = 'DEBUG'
+# SMART requires an extra parameter 'aud' which corresponds with the FHIR application URL
+c.GenericOAuthenticator.extra_authorize_params = {'aud': fhir_base_url}
+
+# Fetch the config
+smart_config = requests.get(f"{fhir_base_url}/{smart_config_location}").json()
+c.GenericOAuthenticator.authorize_url = smart_config["authorization_endpoint"]
+c.GenericOAuthenticator.token_url = smart_config["token_endpoint"]
+for scope in c.GenericOAuthenticator.scope:
+    if scope not in smart_config["scopes_supported"]:
+        raise AttributeError("Scope {scope} not supported through SMART application")
+# With the supplied scopes, auth code also grants an ID token
+c.GenericOAuthenticator.userdata_from_id_token = True
+# Only one field to derive a name from, and it contains (at least) slashes
+c.GenericOAuthenticator.username_claim = lambda r: r['fhirUser'].replace('/', '_')


### PR DESCRIPTION
Example of how to connect to a FHIR application via SMART. Very rudimentary.

Reproduce:
1. Clone `https://github.com/smart-on-fhir/smart-dev-sandbox`
2. `cd smart-dev-sandbox`
3. `docker compose up`
4. Set up configuration on `localhost:4000`:
  - Launch Type: Provider Standalone Launch
  - FHIR Version: R4 (most modern)
  - Providers:  [3] # or whichever
5. `cd /path/to/oauthenticator/examples/smart-app/`
6. `./run.sh`
7. Authenticate on `localhost:8000`